### PR TITLE
Add template "main"

### DIFF
--- a/client/client.html
+++ b/client/client.html
@@ -2,7 +2,7 @@
     <title>scrumLive via MeteorJS</title>
 </head>
 
-<body>
+<template name="main">
 
     <div class="ui grid">
         <!--<div class="one wide column"></div>-->
@@ -36,7 +36,7 @@
 
     </div>
 
-</body>
+</template>
 
 
 <template name="nav">


### PR DESCRIPTION
Solves the error "Sorry, couldn't find a template named main. Are you sure you defined it?" which was caused by the template "main" not being defined. Iron Router needs to call a template, so if you don't supply it a template it automatically calls a template with the same name as the route (which, in this case, was “main”).

The body tags are also unnecessary with templates, as the templates are automatically rendered inside the body element.
